### PR TITLE
Fix pet names not appearing in PoH

### DIFF
--- a/src/main/java/com/pappymint/namedpets/NamedPetsPlugin.java
+++ b/src/main/java/com/pappymint/namedpets/NamedPetsPlugin.java
@@ -177,27 +177,30 @@ public class NamedPetsPlugin extends Plugin
 	}
 
 	private void onNameMenuEntryOptionClicked(NPC pet) {
+		int petId = pet.getId();
+		String petNPCName = pet.getName();
 		chatboxPanelManager.openTextInput("Name your " + pet.getName())
 			.value(getExistingPetName(pet.getId()))
 			.onDone((input) ->
 			{
-				savePetName(pet, input);
+				savePetName(petId, petNPCName, input);
 			})
 			.build();
 	}
 
 	/**
 	 * Save a pet name into config manager
-	 * @param petNpc Pet NPC
+	 * @param petId Pet Id
+	 * @param petNPCName NPC name of pet
 	 * @param petName Pet name to save
 	 */
-	private void savePetName(NPC petNpc, String petName)
+	private void savePetName(int petId, String petNPCName, String petName)
 	{
 		if (Objects.equals(petName, "") || petName == null) {
-			pluginConfigManager.unsetPetName(petNpc.getId());
+			pluginConfigManager.unsetPetName(petId);
 		} else {
-			pluginConfigManager.setPetName(petNpc.getId(), petName);
-			pluginConfigManager.setPetNPCName(petNpc.getId(), petNpc.getName());
+			pluginConfigManager.setPetName(petId, petName);
+			pluginConfigManager.setPetNPCName(petId, petNPCName);
 		}
 	}
 


### PR DESCRIPTION
Resolves [Pets names do not show up in POH](https://github.com/pappymint/named-pets-runelite/issues/6)

My guess is this broke from a RuneLite API update in February. Tested this change on some of my own broken pets.

Plugin users will have to re-enter their broken pet names, but after that, they should be good to go!